### PR TITLE
Store Max Players in State

### DIFF
--- a/src/rooms/GameRoom.js
+++ b/src/rooms/GameRoom.js
@@ -5,11 +5,23 @@ const { GameRoomState } = require('./schema/GameRoomState')
 const { PlayerState } = require('./schema/PlayerState')
 
 exports.GameRoom = class extends colyseus.Room {
+  /**
+   * Called when a new game room is created.
+   * Sets up the game room state and event
+   * handlers for everything that happens
+   * in the game.
+   *
+   * @param {*} options Options from the client
+   */
   onCreate (options) {
     this.setState(new GameRoomState())
 
+    // Set room ID to random alphabetic code like 'ABCDE'
     this.roomId = generateRoomId()
+
+    // Set the number of max clients
     this.maxClients = config.maxClients
+    this.state.maxPlayers = this.maxClients
 
     /**
      * Event handler for the `player_set_displayName` event.

--- a/src/rooms/schema/GameRoomState.js
+++ b/src/rooms/schema/GameRoomState.js
@@ -20,6 +20,11 @@ class GameRoomState extends schema.Schema {
 
 schema.defineTypes(GameRoomState, {
   /**
+   * The maximum number of players allowed in
+   * a game room.
+   */
+  maxPlayers: 'uint8',
+  /**
    * The ordered list of players in the game room.
    * Imagine this as a cycle, so if you want the
    * next person after the last,


### PR DESCRIPTION
We previously discussed how the `room` class doesn't store the number of max clients allowed... so I stored it separately in the GameRoomState. Now the frontend will be able to read it, and in the future we can make it customizable.